### PR TITLE
fix bug for autosym. Code improvement. Test cases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eof=lf

--- a/test/co2_autosym.nw
+++ b/test/co2_autosym.nw
@@ -1,0 +1,21 @@
+echo
+
+start co2_autosym
+charge 0
+
+GEOMETRY
+O 3.82 4.82 5.0
+C 3.0 4.0 5.0
+O 2.18 3.18 5.0
+end
+
+basis spherical
+* library def2-svp
+end
+
+dft
+xc b3lyp
+convergence energy 1e-8
+end
+
+task dft 

--- a/test/co2_noautosym.nw
+++ b/test/co2_noautosym.nw
@@ -1,0 +1,21 @@
+echo
+
+start co2_noautosym
+charge 0
+
+geometry noautosym
+O 3.82 4.82 5.0
+C 3.0 4.0 5.0
+O 2.18 3.18 5.0
+end
+
+basis spherical
+* library def2-svp
+end
+
+dft
+xc b3lyp
+convergence energy 1e-8
+end
+
+task dft 

--- a/test/co2_noautosym_nocenter.nw
+++ b/test/co2_noautosym_nocenter.nw
@@ -1,0 +1,21 @@
+echo
+
+start co2_noautosym_nocenter
+charge 0
+
+GEOMETRY noautosym nocenter
+O 3.82 4.82 5.0
+C 3.0 4.0 5.0
+O 2.18 3.18 5.0
+end
+
+basis spherical
+* library def2-svp
+end
+
+dft
+xc b3lyp
+convergence energy 1e-8
+end
+
+task dft 

--- a/test/co2_nocenter.nw
+++ b/test/co2_nocenter.nw
@@ -1,0 +1,21 @@
+echo
+
+start co2_nocenter
+charge 0
+
+GEOMETRY nocenter
+O 3.82 4.82 5.0
+C 3.0 4.0 5.0
+O 2.18 3.18 5.0
+end
+
+basis spherical
+* library def2-svp
+end
+
+dft
+xc b3lyp
+convergence energy 1e-8
+end
+
+task dft 

--- a/test/co2_noprint.nw
+++ b/test/co2_noprint.nw
@@ -1,0 +1,21 @@
+echo
+
+start co2_noprint
+charge 0
+
+geometry noprint
+O 3.82 4.82 5.0
+C 3.0 4.0 5.0
+O 2.18 3.18 5.0
+end
+
+basis spherical
+* library def2-svp
+end
+
+dft
+xc b3lyp
+convergence energy 1e-8
+end
+
+task dft 

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/bash
+
+if command -v nwchem &> /dev/null; then
+    echo "Found NWChem."
+else
+    echo "Please set NWCHEM_TOP/bin/LINUX64 to PATH."
+    exit 1
+fi
+
+if [ -x ../dplot.py ]; then
+        echo "dplot.py has execute permission."
+    else
+        echo "Please set permision for dplot.py (chmod +x)"
+		exit 1
+fi
+
+echo ""
+
+echo "-------"
+echo "autosym"
+nwchem co2_autosym.nw > co2_autosym.out
+../dplot.py -i co2_autosym.nw -o co2_autosym.out -m co2_autosym.movecs -l 11 
+nwchem dplot.nw > 1.out
+echo "-------"
+echo "noautosym nocenter"
+nwchem co2_noautosym_nocenter.nw > co2_noautosym_nocenter.out
+../dplot.py -i co2_noautosym_nocenter.nw -o co2_noautosym_nocenter.out -m co2_noautosym_nocenter.movecs -l 11 
+nwchem dplot.nw > 2.out
+echo "-------"
+echo "noautosym"
+nwchem co2_noautosym.nw > co2_noautosym.out
+../dplot.py -i co2_noautosym.nw -o co2_noautosym.out -m co2_noautosym.movecs -l 11 
+nwchem dplot.nw > 4.out
+echo "-------"
+echo "nocenter"
+nwchem co2_nocenter.nw > co2_nocenter.out
+../dplot.py -i co2_nocenter.nw -o co2_nocenter.out -m co2_nocenter.movecs -l 11 
+nwchem dplot.nw > 3.out
+echo "-------"
+echo "noprint"
+nwchem co2_noprint.nw > co2_noprint.out
+../dplot.py -i co2_noprint.nw -o co2_noprint.out -m co2_noprint.movecs -l 11 
+nwchem dplot.nw > 4.out
+
+
+echo ""
+echo ""
+echo "Note: For noprint (the same as --output no), no output is used to define limitXYZ."
+echo "WARNING is expected. Users need to swap axes manually [autosym] if plots are not as expected."
+echo "----------------------------------------------"
+echo "It is better to use dplot.py with output file."


### PR DESCRIPTION
+ Try to define LimitXYZ from output geometry [rotated,translated] rather input
+ If not applicable, try to define limitXYZ based on the presence of "noautosym" and "nocenter" keyword.
+ Code improvement: NWChem allows both upper and lower cases (geometry and GEOMETRY). String comparision should be normalized to lower() first. Only print 4 decimal places.
+ Add automatic test job